### PR TITLE
Fix: Hitch Warning on heartbeat

### DIFF
--- a/code/build.sh
+++ b/code/build.sh
@@ -94,7 +94,7 @@ fi
 compiler="$cc -Os -O1 -O3 -s -fvisibility=hidden -w -Wl,--exclude-libs,ALL"
 
 if [ $DEBUG = true ]; then
-compiler="$cc -g -w -Wl,--exclude-libs,ALL"
+compiler="$cc -g -w -Wl,--exclude-libs,ALL -D_REENTRANT -lpthread"
 #compiler="$cc -DxDEBUG -DDEBUG -Os -O1 -O3 -s -fvisibility=hidden -w -Wl,--exclude-libs,ALL"
 fi
 
@@ -209,5 +209,5 @@ $compiler -m32 -shared -L/lib32 -L./lib -o ./bin/codextended.so $obj -Os -s -lz 
 fi
 fi
 #rm -rf ./obj
-find /home/ext/obj -name '*.o' ! -name 'duktape.o' -delete
+find ./obj -name '*.o' ! -name 'duktape.o' -delete
 echo "Done."

--- a/code/server.h
+++ b/code/server.h
@@ -26,6 +26,15 @@
 #include "shared.h"
 #include "script.h"
 
+/*
+    pthreads for HeartBeat in threads
+    unistd for using sleep while development/testing 
+    //Nuke (t-knapp)
+*/
+
+#include <pthread.h>
+//#include <unistd.h>
+
 #if CODPATCH == 1
 #define svsclients_ptr 0x83B67AC
 #define clientsize 370940
@@ -133,6 +142,12 @@ typedef struct {
 } challenge_t;
 
 #pragma pack(push, 1)
+
+//Argument struct passed to heartbeat thread
+typedef struct {
+    const char *hbname;
+    netadr_t adr;
+} heartbeat_t;
 
 typedef int sharedEntity_t;
 


### PR DESCRIPTION
Using pthreads for sending heartbeats to masterserver to avoid lags (~5000ms) if masterserver has high latency.

To simulate/test high latency include _unistd.h_ in server.h and user _sleep(3)_ for simulating 3000ms latency.
Comment out the threading stuff and observe the server lags if _sleep(3)_ is used in **SV_MasterHeartBeat(const char* hbname)** before **NET_OutOfBandPrint(...)**.

Using detached pthreads fixed this lags.